### PR TITLE
Use random state 42 instead of 123

### DIFF
--- a/notebooks/04.Training_and_Testing_Data.ipynb
+++ b/notebooks/04.Training_and_Testing_Data.ipynb
@@ -84,7 +84,7 @@
     "train_X, test_X, train_y, test_y = train_test_split(X, y, \n",
     "                                                    train_size=0.5,\n",
     "                                                    test_size=0.5,\n",
-    "                                                    random_state=123)\n",
+    "                                                    random_state=42)\n",
     "print(\"Labels for training and testing data\")\n",
     "print(train_y)\n",
     "print(test_y)"
@@ -137,7 +137,7 @@
     "train_X, test_X, train_y, test_y = train_test_split(X, y, \n",
     "                                                    train_size=0.5,\n",
     "                                                    test_size=0.5,\n",
-    "                                                    random_state=123,\n",
+    "                                                    random_state=42,\n",
     "                                                    stratify=y)\n",
     "\n",
     "print('All:', np.bincount(y) / float(len(y)) * 100.0)\n",


### PR DESCRIPTION
As mentioned in the scipy tutorial, the speaker asked hte audience to make a pull request to change random state from 123 to 42 because it is a better number.